### PR TITLE
Fix hardcoded

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Meetup oauth2 sdk starter kit
 
-Example usage
+Example usage (for latest working example see index.html)
 
     <html>
       <head>
@@ -29,6 +29,3 @@ Example usage
       </head>
       <body></body>
     </html>
-
-
-

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # Meetup oauth2 sdk starter kit
 
+Prior to doing this, you'll need to get your Meetup Consumer Key at: https://secure.meetup.com/meetup_api/oauth_consumers/
+As well, you'll need to test this on a server that resolves to the "Redirect URI" specified on your configured OAuth Consumer
+
 Example usage (for latest working example see index.html)
 
     <html>

--- a/index.html
+++ b/index.html
@@ -5,12 +5,14 @@
     <script type="text/javascript" src="jquery.min.js"></script>
     <script type="text/javascript" src="mu.api.js"></script>
     <script type="text/javascript">
+    var MEETUP_API_EVENTS_URL = "https://api.meetup.com/2/events?access_token=";
+    var MEETUP_CLIENT_ID = "YOUR_MEETUP_CONSUMER_KEY;
       // initialize api
       api = mu.Api({
-          clientId: "97271o4gabbrq7efdchn7fienh"
+          clientId: MEETUP_CLIENT_ID
           , onMember: function(member, token) {
               $("#connect").hide(); $("#disconnect").show();
-              $.getJSON("https://api.meetup.com/2/events?access_token=" + token +
+              $.getJSON(MEETUP_API_EVENTS_URL + token +
                         "&member_id=self&fields=short_link&page=10&callback=?", function(evts) {
                   var el = $("#events"), buff = [];
                   $.map(evts.results, function(e) {
@@ -19,11 +21,10 @@
                   el.append(buff.join(''));
               });
               $("#member").html(
-                  "<img class='avatar' src=" + member.photo.thumb_link + " /> Hey " +
-                      member.name.link(member.link) + " | <a href='#' id='disconnect'>Logout</a>");
+                  "Hey " + member.name.link(member.link) + " | <a href='#' id='disconnect'>Logout</a>");
           }
       });
-      
+
       (function($){
           $(function() {
               $("#connect").live('click', function(e) {

--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
     <script type="text/javascript" src="mu.api.js"></script>
     <script type="text/javascript">
     var MEETUP_API_EVENTS_URL = "https://api.meetup.com/2/events?access_token=";
-    var MEETUP_CLIENT_ID = "YOUR_MEETUP_CONSUMER_KEY;
+    var MEETUP_CLIENT_ID = "YOUR_MEETUP_CONSUMER_KEY";
       // initialize api
       api = mu.Api({
           clientId: MEETUP_CLIENT_ID

--- a/mu.api.js
+++ b/mu.api.js
@@ -1,11 +1,14 @@
 window.mu = window.mu || {};
 
-/** Provides a thin layer around an oauth2 follow for authorizing 
+var MEETUP_OAUTH2_URL = "https://secure.meetup.com/oauth2/authorize/?response_type=token&client_id=";
+var MEETUP_API_SELF_URL = "https://api.meetup.com/2/member/self";
+
+/** Provides a thin layer around an oauth2 follow for authorizing
  *  a client to access a Meetup member's data
- *  @todo remove jquery dep for making ajax req 
+ *  @todo remove jquery dep for making ajax req
  *  @todo make sure this works in older browsers */
 window.mu.Api = (function(win, $) {
-    return function(opts) {        
+    return function(opts) {
 
         // if user-agent supports local storage, use that, else just use memory
         var storageFallbacks = function() {
@@ -46,7 +49,7 @@ window.mu.Api = (function(win, $) {
         // authorization
         , redirectUri = opts.redirectUri || window.location.href
 
-        // function invoked when meetup user denies authorization 
+        // function invoked when meetup user denies authorization
         , onAuthDenial = opts.onAuthDenial || function(err) {
             alert('override onAuthDenial: function(err)...');
         }
@@ -59,7 +62,7 @@ window.mu.Api = (function(win, $) {
         // function invoked after a user authorizes and before
         // onMember
         , afterAuth = opts.afterAuth || function(mem, token) {
-            
+
         }
 
         // function invoked on a page refresh if a user is logged in
@@ -69,14 +72,14 @@ window.mu.Api = (function(win, $) {
 
         // support  for custom permission scopes
         // http://www.meetup.com/meetup_api/auth/#oauth2-scopes
-        , scopes = opts.scopes || ['ageless'] 
+        , scopes = opts.scopes || ['ageless']
 
         // location for auth
-        , authorization = "https://secure.meetup.com/oauth2/authorize/?response_type=token&client_id=" +
+        , authorization = MEETUP_OAUTH2_URL +
                 client_id + "&scope=" + scopes.join(',') + "&redirect_uri=" + redirectUri
 
         // api call to get the authorized members data
-        , member = "https://api.meetup.com/2/member/self"
+        , member = MEETUP_API_SELF_URL
 
         , requestAuthorization = function() {
             var width = 500, height = 350
@@ -86,11 +89,11 @@ window.mu.Api = (function(win, $) {
                 authorization,
                 "Meetup",
                 ["height=", height, ",width=", width,
-                 ",top=", top, ",left=", left].join(''));    
+                 ",top=", top, ",left=", left].join(''));
         };
 
         $(function() {
-      
+
             if(storage) {
                 var ls = storage;
 
@@ -143,10 +146,10 @@ window.mu.Api = (function(win, $) {
                     onMember(JSON.parse(ls.get('mu_member')), ls.get('mu_token'));
                 }
             } else {
-                onUnsupportedStorage();         
+                onUnsupportedStorage();
             }
         });
-    
+
         // return a means of logging out and in
         return {
             logout: function(after) {


### PR DESCRIPTION
constants created: 
MEETUP_CLIENT_ID
MEETUP_OAUTH2_URL
MEETUP_API_EVENTS_URL
MEETUP_API_SELF_URL

for 2 reasons:
1) a little easier for users to find where they need to plug in their customer key
2) easier for meetup engineer to switch between local, dev, prod, etc
